### PR TITLE
Retry, styles and new default networks

### DIFF
--- a/packages/perfrunner-cli/package-lock.json
+++ b/packages/perfrunner-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "perfrunner",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/perfrunner-cli/package.json
+++ b/packages/perfrunner-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perfrunner",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Command-line-interface for the perfrunner - automated UI performance test tool",
   "main": "./dist/cli.js",
   "scripts": {
@@ -47,8 +47,8 @@
   },
   "dependencies": {
     "command-line-args": "~5.1.1",
-    "perfrunner-core": "^0.7.2",
-    "perfrunner-reporters": "^0.7.2"
+    "perfrunner-core": "^0.7.3",
+    "perfrunner-reporters": "^0.7.3"
   },
   "files": [
     "dist",

--- a/packages/perfrunner-cli/readme.md
+++ b/packages/perfrunner-cli/readme.md
@@ -47,13 +47,13 @@ npx perfrunner https://drag13.io
 
 | Command               | Alias | Description                                                                                                      | Default value          | IsRequired |
 | --------------------- | ----- | ---------------------------------------------------------------------------------------------------------------- | ---------------------- | ---------- |
-| --cache               | -C    | Using browser cahce                                                                                              | `false`                | Optional   |
+| --cache               | -C    | Using browser cahce. Mutliple values supported. <`true`/`false`>                                                 | `false`                | Optional   |
 | --chrome-args         | -     | Additional arguments to pass to the browser instance. Should be passed using camelCase style like: `"noSandbox"` | `undefined`            | Optional   |
 | --comment             | -     | Provide additional information about test. May be used from reporter                                             | `undefined`            | Optional   |
 | --executablePath      | -E    | Sets path to the Chrome instance                                                                                 | `undefined`            | Optional   |
 | --ignore-default-args | -     | Ignore defaultArgs for launching Chromium                                                                        | `false`                | Optional   |
 | --log-level           | -     | Setup log level: <`verbose`>                                                                                     | `undefined`            | Optional   |
-| --network             | -     | Setup network contions. Multiple values supported. <`online`/`regular-4g`/`fast-3g`/`hspa`/`slow-3g`>            | `fast-3g`              | Optional   |
+| --network             | -     | Setup network contions. Multiple values supported. <`online`/`regular-4g`/`fast-3g`/`hspa`/`slow-3g`>            | `online`,`fast-3g`     | Optional   |
 | --no-headless         | -     | Disables headless mode                                                                                           | `false`                | Optional   |
 | --purge               | -     | Remove old data before the test run                                                                              | `false`                | Optional   |
 | --reporter            | -     | Specify reporter                                                                                                 | `html`                 | Optional   |
@@ -88,7 +88,7 @@ Example:
 This is default reporter so you don't need to name it
 
 ```cmd
-npx perfrunner drag13@github.io
+npx perfrunner drag13.io
 ```
 
 ### JSON
@@ -98,7 +98,7 @@ Generates output as JSON file
 Example:
 
 ```cmd
-npx perfrunner drag13@github.io --reporter json
+npx perfrunner drag13.io --reporter json
 ```
 
 ## CSV
@@ -106,7 +106,7 @@ npx perfrunner drag13@github.io --reporter json
 Generates output as CSV file
 
 ```cmd
-npx perfrunner drag13@github.io --reporter csv
+npx perfrunner drag13.io --reporter csv
 ```
 
 ## Custom

--- a/packages/perfrunner-cli/src/arguments/args.ts
+++ b/packages/perfrunner-cli/src/arguments/args.ts
@@ -1,7 +1,8 @@
 import { OptionDefinition } from 'command-line-args';
 import { NetworkSetup } from 'perfrunner-core';
-import { Url, Network, ArgsLikeString, StringOrNumber, LogLevel, HSPA } from './typeFactories';
+import { Url, Network, ArgsLikeString, StringOrNumber, LogLevel, Bool } from './typeFactories';
 import { argsLike } from '../utils';
+import { HSPA_Plus, Original } from './typeFactories/network';
 
 export type TestRunConditions = {
     url: URL;
@@ -24,7 +25,7 @@ export type TestRunConditions = {
 export type PerformanceConditions = {
     network: NetworkSetup[];
     throttling: number;
-    cache: boolean;
+    cache: boolean[];
 };
 
 export interface ConsoleArguments extends TestRunConditions, PerformanceConditions {}
@@ -40,12 +41,12 @@ type ParamsMap = { [key in keyof ConsoleArguments]: Omit<ProfileOptionDefintion<
 const options: ParamsMap = {
     url: { type: Url, defaultOption: true },
     timeout: { type: Number, defaultValue: 90_000 },
-    cache: { type: Boolean, defaultValue: false, alias: 'C' },
+    cache: { type: Bool, multiple: true, defaultValue: [false], alias: 'C' },
     throttling: { type: Number, defaultValue: 2, alias: 'T' },
-    network: { type: Network, defaultValue: [HSPA], multiple: true },
+    network: { type: Network, defaultValue: [Original, HSPA_Plus], multiple: true },
     output: { type: String, defaultValue: 'generated' },
     purge: { type: Boolean, defaultValue: false },
-    reporter: { type: String as any, multiple: true, defaultValue: ['html'] },
+    reporter: { type: String, multiple: true, defaultValue: ['html'] },
     runs: { type: Number, defaultValue: 3, alias: 'R' },
     noHeadless: { type: Boolean, defaultValue: false },
     comment: { type: String },

--- a/packages/perfrunner-cli/src/arguments/typeFactories/bool.ts
+++ b/packages/perfrunner-cli/src/arguments/typeFactories/bool.ts
@@ -1,0 +1,1 @@
+export const Bool = (v: string | undefined) => (v && v.toLowerCase() === 'true' ? true : false);

--- a/packages/perfrunner-cli/src/arguments/typeFactories/index.ts
+++ b/packages/perfrunner-cli/src/arguments/typeFactories/index.ts
@@ -3,5 +3,6 @@ import { Url } from './url';
 import { ArgsLikeString } from './arg-like-string';
 import { StringOrNumber } from './string-number';
 import { LogLevel } from './log-level';
+import { Bool } from './bool';
 
-export { Network, Url, ArgsLikeString, StringOrNumber, LogLevel, HSPA };
+export { Network, Url, ArgsLikeString, StringOrNumber, LogLevel, HSPA, Bool };

--- a/packages/perfrunner-cli/src/arguments/typeFactories/network.ts
+++ b/packages/perfrunner-cli/src/arguments/typeFactories/network.ts
@@ -3,7 +3,7 @@
 
 import { NetworkSetup } from 'perfrunner-core';
 
-export const NoThrottlingConditions: NetworkSetup = {
+export const Original: NetworkSetup = {
     downloadThroughput: -1,
     uploadThroughput: -1,
     latency: 0,
@@ -42,7 +42,7 @@ export const Network = (networkType: string | undefined) => {
     switch (networkType) {
         case 'no-throttling':
         case 'online':
-            return NoThrottlingConditions;
+            return Original;
         case 'slow-3g':
             return Slow3g;
         case 'hspa':
@@ -53,6 +53,6 @@ export const Network = (networkType: string | undefined) => {
         case 'regular-4g':
             return FourG;
         default:
-            return HSPA;
+            throw new Error(`Unknow network setup: ${networkType}`);
     }
 };

--- a/packages/perfrunner-cli/src/mapper/mapper.test.ts
+++ b/packages/perfrunner-cli/src/mapper/mapper.test.ts
@@ -6,7 +6,7 @@ import { ConsoleArguments } from '../arguments';
 
 describe('test', () => {
     const input: ConsoleArguments = {
-        cache: true,
+        cache: [true],
         chromeArgs: [],
         comment: '',
         ignoreDefaultArgs: false,
@@ -23,6 +23,7 @@ describe('test', () => {
         timeout: 500,
         url: new URL('http://drag13.io'),
         waitFor: 500,
+        executablePath: 'test'
     };
 
     const result = mapArgs(input);

--- a/packages/perfrunner-core/package-lock.json
+++ b/packages/perfrunner-core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "perfrunner-core",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/perfrunner-core/package.json
+++ b/packages/perfrunner-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perfrunner-core",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Automated UI performance test tool to measure performance changes for the web apps and sites",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/packages/perfrunner-core/src/validation/validation.ts
+++ b/packages/perfrunner-core/src/validation/validation.ts
@@ -48,6 +48,7 @@ const optionsValidationScheme: ValidationScheme = {
                 return optionalString();
         }
     }),
+    executablePath: optionalString(),
 };
 
 export const validator = object().shape(optionsValidationScheme);

--- a/packages/perfrunner-reporters/package-lock.json
+++ b/packages/perfrunner-reporters/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "perfrunner-reporters",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/perfrunner-reporters/package.json
+++ b/packages/perfrunner-reporters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perfrunner-reporters",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Home of the perfrunner reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,7 +43,7 @@
     "jquery": "~3.5.1",
     "json2csv": "~5.0.1",
     "mustache": "~4.0.1",
-    "perfrunner-core": "^0.7.2",
+    "perfrunner-core": "^0.7.3",
     "popper.js": "~1.16.1"
   },
   "files": [

--- a/packages/perfrunner-reporters/src/reporters/html/charts/registry.ts
+++ b/packages/perfrunner-reporters/src/reporters/html/charts/registry.ts
@@ -20,4 +20,4 @@ export const getReporterRegistry = () => {
     };
 };
 
-export const defaultReporterNames = [entries.name, marks.name, resources.name, metrics.name, resourcesBeforeFcp.name];
+export const defaultReporterNames = [marks.name, entries.name, metrics.name, resourcesBeforeFcp.name, resources.name];

--- a/packages/perfrunner-reporters/src/reporters/html/index.html
+++ b/packages/perfrunner-reporters/src/reporters/html/index.html
@@ -42,9 +42,6 @@
             {{#pages}}
             <div class="tab-pane {{pageClass}}" id="{{contentId}}" role="tabpanel">
                 <div class="charts">
-                    {{#reporters}}
-                    <div class="chart-container"><canvas></canvas> </div>
-                    {{/reporters}}
                 </div>
             </div>
             {{/pages}}

--- a/packages/perfrunner-reporters/src/reporters/html/index.ts
+++ b/packages/perfrunner-reporters/src/reporters/html/index.ts
@@ -49,7 +49,7 @@ const defaultReporter: IReporter = async (outputFolder, data, args) => {
 
     const template = readFileSync(templatePath, { encoding: 'utf-8' });
     const result = render(template, {
-        href: href.length < 42 ? href : href.substr(0, 41),
+        href: href.length < 43 ? href : href.substr(0, 42),
         pages: groupedData.map((d, i) => getPageMetadata(getTabName(d, i), i === 0)),
         reporters: reporters,
         payload: sanitizeJson(JSON.stringify(groupedData)),

--- a/packages/perfrunner-reporters/src/reporters/html/render.ts
+++ b/packages/perfrunner-reporters/src/reporters/html/render.ts
@@ -17,9 +17,8 @@ import { IPerformanceResult } from 'perfrunner-core';
         .filter(defined);
 
     data.forEach((performanceResult, groupId) => {
-        reportersToRender.forEach((reporter, i) => {
-            const canvasNumber = groupId * reportersToRender.length + i;
-            reporter.render(document.querySelectorAll('canvas')[canvasNumber], performanceResult);
+        reportersToRender.forEach((reporter) => {
+            reporter.render(document.querySelectorAll('.charts')[groupId]!, performanceResult);
         });
     });
 })('nav-tab', 'nav-tabContent', (window as any).data, (window as any).renderArgs);

--- a/packages/perfrunner-reporters/src/reporters/html/styles/styles.css
+++ b/packages/perfrunner-reporters/src/reporters/html/styles/styles.css
@@ -8,28 +8,27 @@ h1 {
     text-align: center;
     font-family: monospace, Verdana, sans-serif;
     margin: 0;
-    font-size: 1.5em
+    font-size: 1.5em;
 }
 
 .charts {
     display: flex;
-    flex-wrap: wrap
+    flex-wrap: wrap;
 }
 
 .chart-container {
     position: relative;
-    min-height: 300px;
     width: 100%;
-    max-width: 100%
+    max-width: 100%;
 }
 
-@media screen and (min-width:768px) {
+@media screen and (min-width: 1200px) {
     .chart-container {
         max-width: 50%;
     }
 }
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 1600px) {
     .chart-container {
         max-width: 33%;
     }

--- a/packages/perfrunner-reporters/src/utils/dom.ts
+++ b/packages/perfrunner-reporters/src/utils/dom.ts
@@ -1,0 +1,18 @@
+type CreteElementOptions = {
+    className?: string;
+    child?: Element;
+};
+
+export function createElement<K extends keyof HTMLElementTagNameMap>(key: K, options?: CreteElementOptions) {
+    const element = document.createElement(key);
+
+    if (options?.className) {
+        element.className = options.className;
+    }
+
+    if (options?.child) {
+        element.appendChild(options.child);
+    }
+
+    return element;
+}

--- a/packages/perfrunner-reporters/src/utils/index.ts
+++ b/packages/perfrunner-reporters/src/utils/index.ts
@@ -6,6 +6,7 @@ import { defined, isNullOrEmpty, isNullOrNaN } from './misc';
 import { ResourceType, getResourceType } from './res';
 import { hash } from './hash';
 import { exclude } from './object';
+import { createElement } from './dom';
 
 export { TRANSPARENT, color };
 export { toMs, toBytes };
@@ -15,3 +16,4 @@ export { defined, isNullOrEmpty, isNullOrNaN };
 export { ResourceType, getResourceType };
 export { hash };
 export { exclude };
+export { createElement };

--- a/packages/perfrunner-reporters/src/utils/res.ts
+++ b/packages/perfrunner-reporters/src/utils/res.ts
@@ -79,7 +79,6 @@ const getResourceType = (pEntry: ExtendedPerformanceEntry): ResourceType => {
         }
     }
 
-    console.log(`${pEntry.name} ${pEntry.entryType}, ${pEntry.extension}`);
     return 'unknown';
 };
 


### PR DESCRIPTION
* Updated styles for the charts
* Changed default network to origin and fast3g
* Added support for cache/cacheless run
* Added one retry
* Added skipping of rendering the empty chart
* Added LCP to log
* Addded validation for executablePath